### PR TITLE
Failing test for killing child process

### DIFF
--- a/lib/wait_for_it.rb
+++ b/lib/wait_for_it.rb
@@ -94,6 +94,10 @@ class WaitForIt
         cleanup
       end
     end
+
+  rescue WaitForItTimeoutError => e
+    cleanup
+    raise e
   end
 
   attr_reader :timeout, :log
@@ -140,11 +144,23 @@ class WaitForIt
   # Kills the process and removes temporary files
   def cleanup
     shutdown
-    @tmp_file.close
-    @log.unlink
+    close_log
+    unlink_log
   end
 
 private
+
+  def close_log
+    @tmp_file.close if @tmp_file
+  end
+
+  def unlink_log
+    @log.unlink if @log
+  rescue Errno::ENOENT
+    # File already unlinked
+  end
+
+
   def set_log
     @tmp_file  = Tempfile.new(["wait_for_it", ".log"])
     log_file   = Pathname.new(@tmp_file)

--- a/lib/wait_for_it.rb
+++ b/lib/wait_for_it.rb
@@ -169,9 +169,11 @@ private
   end
 
   def spawn(command, redirection, env_hash = {})
-    env     = env_hash.map {|key, value| "#{ key.to_s.shellescape }=#{ value.to_s.shellescape }" }.join(" ")
-    command = "/usr/bin/env #{ env } bash -c #{ command.shellescape } #{ redirection } #{ log }"
-    @pid = Process.spawn("#{ command }")
+    env = {}
+    env_hash.each {|k, v| env[k.to_s] = v.to_s }
+
+    # Must exec so when we kill the PID it kills the child process
+    @pid = Process.spawn(env, "exec #{ command } #{ redirection } #{ log }")
   end
 
   def convert_to_regex(input)

--- a/spec/fixtures/never_exits.rb
+++ b/spec/fixtures/never_exits.rb
@@ -1,0 +1,8 @@
+STDOUT.sync = true
+
+puts "booted"
+
+while true
+  puts "running"
+  sleep 1
+end

--- a/spec/fixtures/sleep.rb
+++ b/spec/fixtures/sleep.rb
@@ -1,3 +1,5 @@
+STDOUT.sync = true
+
 puts "Started"
 val = ENV["SLEEP"].to_i
 sleep val

--- a/spec/wait_for_it_spec.rb
+++ b/spec/wait_for_it_spec.rb
@@ -5,6 +5,18 @@ describe WaitForIt do
     expect(WaitForIt::VERSION).not_to be nil
   end
 
+  it "sends TERM to child on exit" do
+    options = { wait_for: "booted" }
+
+    WaitForIt.new("ruby #{ fixture_path("never_exits.rb") }", options) do |spawn|
+      spawn.send(:shutdown)
+      count_before = spawn.count("running")
+      sleep 1
+      count_after = spawn.count("running")
+      expect(count_before).to eq(count_after)
+    end
+  end
+
   it "raises an error if a process takes too long to boot" do
     expect {
       options = { timeout: 1, env: { SLEEP: 10 }, wait_for: "Done" }
@@ -41,7 +53,7 @@ describe WaitForIt do
   describe 'wait!' do
     it 'raises if process takes too long too long' do
       expect {
-        options = { env: { SLEEP: 10 }, wait_for: "Started"}
+        options = { env: { SLEEP: 100 }, wait_for: "Started"}
         WaitForIt.new("ruby #{ fixture_path("sleep.rb") }", options) do |spawn|
           spawn.wait!("Done", 1)
         end


### PR DESCRIPTION
When we send TERM to the process we are sending it to bash, which does not pick up the command and echo it to the child.