### PR TITLE
Support unsetting environment variables

### DIFF
--- a/lib/wait_for_it.rb
+++ b/lib/wait_for_it.rb
@@ -170,7 +170,7 @@ private
 
   def spawn(command, redirection, env_hash = {})
     env = {}
-    env_hash.each {|k, v| env[k.to_s] = v.to_s }
+    env_hash.each {|k, v| env[k.to_s] = v.nil? ? v : v.to_s }
 
     # Must exec so when we kill the PID it kills the child process
     @pid = Process.spawn(env, "exec #{ command } #{ redirection } #{ log }")


### PR DESCRIPTION
Converting all values into strings via `.to_s` means that it's not possible to unset environment variables by passing their value as `nil` to `Process.spawn`. This adds a check to pass through `nil`s without stringification to allow unsetting.